### PR TITLE
Allow bower to install with sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ libffi-dev nodejs libyaml-dev
 
 # Install frontend assets
 sudo npm install -g bower
-sudo -iu ${APP_USER} bower --config.cwd=${APP_DIR} --config.directory=realms/static/vendor --config.interactive=false install
+sudo -iu ${APP_USER} bower --allow-root --config.cwd=${APP_DIR} --config.directory=realms/static/vendor --config.interactive=false install
 
 sudo -iu ${APP_USER} virtualenv ${APP_DIR}/.venv
 


### PR DESCRIPTION
Without `--allow-root`, bower throws the following:

```
bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814

You can however run a command with sudo using --allow-root option
```
