### PR TITLE
nginx static content location root fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Put the following sample configuration in that file.
       # Settings to by-pass for static files 
       location ^~ /static/  {
         # Example:
-        root /full/path/to/realms/static/;
+        root /full/path/to/realms/;
       }
         
       location / {


### PR DESCRIPTION
I just played with this and nginx is keeping the **/static/** in the requesting url and then attempting to find a folder on the file system that looks like **/full/path/to/realms/static/static/...**

This should fix that.