### PR TITLE
Make Elasticsearch searched fields configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ In your Realms Config, have the following options set:
     "SEARCH_TYPE": "elasticsearch"
     "ELASTICSEARCH_URL": "http://127.0.0.1:9200"
 
+Optionally, also set the following option to configure which fields are searchable:
+
+    "ELASTICSEARCH_FIELDS": ["name"]
+
+Allowable values are `"name"`, `"content"`, `"username"`, `"message"`. The default is `["name"]`.
+
 ### Whoosh Setup
 
 Simply install Whoosh to your Python environment, e.g.

--- a/realms/config/__init__.py
+++ b/realms/config/__init__.py
@@ -99,6 +99,7 @@ SEARCH_TYPE = 'simple'  # simple is not good for large wikis
 
 # SEARCH_TYPE = 'elasticsearch'
 ELASTICSEARCH_URL = 'http://127.0.0.1:9200'
+ELASTICSEARCH_FIELDS = ["name"]
 
 # SEARCH_TYPE = 'whoosh'
 WHOOSH_INDEX = '/tmp/whoosh'

--- a/realms/modules/search/models.py
+++ b/realms/modules/search/models.py
@@ -14,7 +14,8 @@ def whoosh(app):
 
 def elasticsearch(app):
     from flask.ext.elastic import Elastic
-    return ElasticSearch(Elastic(app))
+    fields = app.config.get('ELASTICSEARCH_FIELDS')
+    return ElasticSearch(Elastic(app), fields)
 
 
 class Search(object):
@@ -125,8 +126,9 @@ class WhooshSearch(BaseSearch):
 
 
 class ElasticSearch(BaseSearch):
-    def __init__(self, elastic):
+    def __init__(self, elastic, fields):
         self.elastic = elastic
+        self.fields = fields
 
     def index(self, index, doc_type, id_=None, body=None):
         return self.elastic.index(index=index, doc_type=doc_type, id=id_, body=body)
@@ -144,7 +146,7 @@ class ElasticSearch(BaseSearch):
         res = self.elastic.search(index='wiki', body={"query": {
             "multi_match": {
                 "query": query,
-                "fields": ["name"]
+                "fields": self.fields
             }}})
 
         return [hit["_source"] for hit in res['hits']['hits']]


### PR DESCRIPTION
This makes the fields searched by Elasticsearch configurable, allowing searching of article text as well as page titles. Default behaviour remains the same. Also proposed an edit to docs to include the new config option.

- Added config item `ELASTICSEARCH_FIELDS`
- Use the item [in the elasticsearch model](https://github.com/darkindex/realms-wiki/blob/elasticsearch-fields/realms/modules/search/models.py#L17) - is this the correct way to pass this value in?
- Updated README