### PR TITLE
Update DataTables dependency to 1.10.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "store-js": "~1.3.16",
     "bootswatch-dist": "3.2.0-flatly",
     "bootbox": "4.3.0",
-    "datatables": "1.10.3",
+    "datatables": "1.10.7",
     "datatables-plugins": "latest"
   }
 }


### PR DESCRIPTION
This version includes a fix for a DataTables bug that can cause JS errors.
Possibly only affects certain jQuery versions but seems reproducible with 1.11.3

Bug report: https://github.com/DataTables/DataTables/issues/546
Commit: https://github.com/DataTables/DataTablesSrc/commit/485b259e5c