### PR TITLE
Fix subtle bug in new click parameter handling

### DIFF
--- a/realms/commands.py
+++ b/realms/commands.py
@@ -61,7 +61,7 @@ def prompt_and_invoke(ctx, fn):
     for p in fn.params:
         v = click.prompt(p.prompt, p.default, p.hide_input,
                          p.confirmation_prompt, p.type)
-        kw[p.name.upper()] = v
+        kw[p.name] = v
 
     ctx.invoke(fn, **kw)
 


### PR DESCRIPTION
Sorry.

There was a subtle bug in the parameter handling
    
The parameter names must not be converted to upper case before calling
`context.invoke`, because that works with the lowercase names.
    
Before this bugfix,, we had kw like this in the various `setup_*` functions: `{'DB_URI': 'sqlite:////tmp/wiki.db', 'db_uri': 'sqlite:////real/path.db'}` and whichever won was pretty much random (dict sort order)