### PR TITLE
Fix bug with rename page to also delete old page

### DIFF
--- a/realms/modules/search/hooks.py
+++ b/realms/modules/search/hooks.py
@@ -2,7 +2,6 @@ from realms.modules.wiki.models import Wiki
 from realms import search
 
 
-
 @Wiki.after('write_page')
 def wiki_write_page(name, content, message=None, username=None, email=None, **kwargs):
 
@@ -19,5 +18,9 @@ def wiki_write_page(name, content, message=None, username=None, email=None, **kw
 
 
 @Wiki.after('rename_page')
-def wiki_rename_page(*args, **kwargs):
-    pass
+def wiki_rename_page(old_name, *args, **kwargs):
+
+    if not hasattr(search, 'index_wiki'):
+        return
+
+    return search.delete_wiki(old_name)

--- a/realms/modules/search/models.py
+++ b/realms/modules/search/models.py
@@ -92,8 +92,18 @@ class WhooshSearch(BaseSearch):
         writer.update_document(path=id_.decode("utf-8"), body=body["content"].decode("utf-8"))
         writer.commit()
 
+    def delete(self, id_):
+        with self.search_index.searcher() as s:
+            doc_num = s.document_number(path=id_.decode("utf-8"))
+            writer = self.search_index.writer()
+            writer.delete_document(doc_num)
+            writer.commit()
+
     def index_wiki(self, name, body):
         self.index('wiki', 'page', id_=name, body=body)
+
+    def delete_wiki(self, name):
+        self.delete(id_=name)
 
     def delete_index(self, index):
         from whoosh import index as whoosh_index
@@ -133,8 +143,14 @@ class ElasticSearch(BaseSearch):
     def index(self, index, doc_type, id_=None, body=None):
         return self.elastic.index(index=index, doc_type=doc_type, id=id_, body=body)
 
+    def delete(self, index, doc_type, id_):
+        return self.elastic.delete(index=index, doc_type=doc_type, id=id_)
+
     def index_wiki(self, name, body):
         self.index('wiki', 'page', id_=name, body=body)
+
+    def delete_wiki(self, name):
+        self.delete('wiki', 'page', id_=name)
 
     def delete_index(self, index):
         return self.elastic.indices.delete(index=index, ignore=[400, 404])

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -118,6 +118,9 @@ class Wiki(HookMixin):
             # old doesn't exist
             return None
 
+        if old_filename == new_filename:
+            return
+
         if new_filename in self.gittle.index:
             # file is being overwritten, but that is ok, it's git!
             pass

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -140,7 +140,7 @@ def page_write(name):
         if edit_cname in current_app.config.get('WIKI_LOCKED_PAGES'):
             return dict(error=True, message="Page is locked"), 403
 
-        if edit_cname != cname.lower():
+        if edit_cname != cname:
             g.current_wiki.rename_page(cname, edit_cname)
 
         sha = g.current_wiki.write_page(edit_cname,

--- a/realms/static/js/editor.js
+++ b/realms/static/js/editor.js
@@ -73,7 +73,11 @@ var aced = new Aced({
       content: content
     };
 
-    var path = Config['RELATIVE_PATH'] + '/' + data['name'];
+    // If renaming an existing page, use the old page name for the URL to PUT to
+    var subPath = (PAGE_NAME) ? PAGE_NAME : data['name']
+    var path = Config['RELATIVE_PATH'] + '/' + subPath;
+    var newPath = Config['RELATIVE_PATH'] + '/' + data['name'];
+
     var type = (Commit.info['sha']) ? "PUT" : "POST";
 
     $.ajax({
@@ -87,7 +91,7 @@ var aced = new Aced({
         $page_name.addClass('parsley-error');
         bootbox.alert("<h3>" + res['message'] + "</h3>");
       } else {
-        location.href = path;
+        location.href = newPath;
       }
     });
   }

--- a/realms/templates/wiki/edit.html
+++ b/realms/templates/wiki/edit.html
@@ -3,6 +3,8 @@
   <script>
     var Commit = {};
     Commit.info = {{ info|tojson }};
+
+    var PAGE_NAME = '{{ name }}';
   </script>
   <script src="{{ url_for('static', filename='js/editor.js') }}"></script>
 


### PR DESCRIPTION
Fix bug where renaming a page doesn't delete the old page. The editor code (`edit.html` and `editor.js`) needs to know what the existing page name is to do this (right now it only look at the new page name, stored in `$('#page-name')`

Now renaming a page will produce the correct values for `old_name` and `new_name ` in https://github.com/scragg0x/realms-wiki/blob/master/realms/modules/wiki/models.py#L106, so that the `old_name` will be removed.

See my comment in https://github.com/scragg0x/realms-wiki/issues/61

Let me know if there are other preferred conventions (e.g. `PAGE_NAME`)

EDIT: also added functionality to delete search indices for ES and Whoosh (I'm not familiar with Whoosh but tried to piece if together)
EDIT2 (9/29): also found a bug where rename_page() would get called unnecessarily due to an incorrect comparison between old/new