### PR TITLE
Fix rebuild_index to use full path of page when indexing.

### DIFF
--- a/realms/modules/search/commands.py
+++ b/realms/modules/search/commands.py
@@ -28,7 +28,7 @@ def rebuild_index():
             if not page:
                 # Some non-markdown files may have issues
                 continue
-            name = filename_to_cname(page['name'])
+            name = filename_to_cname(page['path'])
             # TODO add email?
             body = dict(name=name,
                         content=page['data'],


### PR DESCRIPTION
Should fix #88. The full path of the pages was not being sent to the search provider when rebuild_index command was run.