### PR TITLE
Add an icon and sort column for pages/dirs in the index

### DIFF
--- a/realms/templates/wiki/index.html
+++ b/realms/templates/wiki/index.html
@@ -3,7 +3,7 @@
 {% block js %}
 <script>
 $(document).ready(function() {
-    $('.data-table').dataTable();
+    $('.data-table').dataTable({'aaSorting': [[0, "asc"], [1, "asc"]]});
 });
 </script>
 {% endblock %}
@@ -18,17 +18,20 @@ $(document).ready(function() {
   <table class="table table-bordered data-table">
     <thead>
     <tr>
+      <th style="width: 1px;"></th>
       <th>Name</th>
       <th class="hidden-xs">Bytes</th>
-      <th>Created</th>
-      <th class="hidden-xs hidden-sm">Modified</th>
+      <th class="hidden-xs hidden-sm">Created</th>
+      <th>Modified</th>
     </tr>
     </thead>
     {% for file in index %}
       <tr>
       {% if file['dir'] %}
+        <td><i class="fa fa-folder-open-o"><span style="display:none;">Dir</span></i></td>
         <td><a href="{{ url_for('wiki.index', path=file['name']) }}">{{ file['name'][path|length:] }}</a></td>
       {% else %}
+        <td><i class="fa fa-file-text-o"><span style="display:none;">Page</span></i></td>
         <td><a href="{{ url_for('wiki.page', name=file['name']) }}">{{ file['name'][path|length:] }}</a></td>
       {% endif %}
         <td class="hidden-xs">{{ file['size'] }}</td>


### PR DESCRIPTION
Also changes the initial sorting to show dirs first then pages.

I don't really know what I'm doing with html/css, so the following things should maybe be improved:
- I'm using text in the icon column with a hidden style so sorting works, I'm not sure if there is a better way.
- I'm also setting the width of that column to 1px to make datatables shrink it as much as possible, not sure if there is a better way for that.