### PR TITLE
Allow all config options to be specified in realms-wiki.json

### DIFF
--- a/realms/config/__init__.py
+++ b/realms/config/__init__.py
@@ -169,8 +169,6 @@ WIKI_LOCKED_PAGES = []
 
 ROOT_ENDPOINT = 'wiki.page'
 
-globals().update(read())
-
 # Used by Flask-Login
 LOGIN_DISABLED = ALLOW_ANON
 
@@ -195,6 +193,8 @@ if ENV != "DEV":
     SQLALCHEMY_ECHO = False
 
 MODULES = ['wiki', 'search', 'auth']
+
+globals().update(read())
 
 if globals().get('AUTH_LOCAL_ENABLE'):
     MODULES.append('auth.local')


### PR DESCRIPTION
I was trying to add a custom module in for some site specific customization, and noticed MODULES could not be specified from the config file.