### PR TITLE
Add gravatar icons to history

### DIFF
--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -289,9 +289,10 @@ class Wiki(HookMixin):
                     change_type = change.type
                 elif change.new.path == file_path:
                     change_type = change.type
-            author_name, author_email = entry.commit.author.split('<')
+            author_name, author_email = entry.commit.author.rstrip('>').split('<')
             versions.append(dict(
                 author=author_name.strip(),
+                author_email=author_email,
                 time=entry.commit.author_time,
                 message=entry.commit.message,
                 sha=entry.commit.id,

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -2,7 +2,7 @@ import itertools
 import sys
 from flask import abort, g, render_template, request, redirect, Blueprint, flash, url_for, current_app
 from flask.ext.login import login_required, current_user
-from realms.lib.util import to_canonical, remove_ext
+from realms.lib.util import to_canonical, remove_ext, gravatar_url
 from .models import PageNotFound
 
 blueprint = Blueprint('wiki', __name__)
@@ -66,7 +66,10 @@ def history(name):
     if current_app.config.get('PRIVATE_WIKI') and current_user.is_anonymous():
         return current_app.login_manager.unauthorized()
 
-    return render_template('wiki/history.html', name=name, history=g.current_wiki.get_history(name))
+    hist = g.current_wiki.get_history(name)
+    for item in hist:
+        item['gravatar'] = gravatar_url(item['author_email'])
+    return render_template('wiki/history.html', name=name, history=hist)
 
 
 @blueprint.route("/_edit/<path:name>")

--- a/realms/static/css/style.css
+++ b/realms/static/css/style.css
@@ -83,9 +83,7 @@
   float: right;
 }
 
-.user-avatar a img {
-  width: 24px;
-  height: 24px;
+.avatar {
   -webkit-box-shadow: 0 1px 3px #1e1e1e;
   -moz-box-shadow: 0 1px 3px #1e1e1e;
   box-shadow: 0 1px 3px #1e1e1e;

--- a/realms/templates/layout.html
+++ b/realms/templates/layout.html
@@ -62,7 +62,7 @@
               <li class="dropdown user-avatar">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                 <span>
-                    <img src="{{ current_user.avatar }}" class="menu-avatar">
+                    <img src="{{ current_user.avatar }}?s=24" class="avatar">
                     <span>{{ current_user.username }} <i class="icon-caret-down"></i></span>
                 </span>
                 </a>

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -22,7 +22,7 @@
           <input type="checkbox" name="versions[]" value="{{ h.sha }}" />
           {% endif %}
         </td>
-        <td>{{ h.author }}</td>
+        <td><img src="{{ h.gravatar }}?s=20" class="avatar"/> {{ h.author }}</td>
         <td><a href="{{ url_for('wiki.commit', name=name, sha=h.sha) }}" class='label label-primary'>View</a> {{ h.message }} </td>
         <td>{{ h.time|datetime }}</td>
       </tr>


### PR DESCRIPTION
This adds author_email to the return of Wiki.get_history, which is used by the history wiki view to generate a gravatar url.
I've also switched the gravatar styling from the menu a bit to be easier to use with gravatar icons in other places, though not sure if I did it the best way.