### PR TITLE
Make datetimes customizable

### DIFF
--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -183,8 +183,11 @@ def create_app(config=None):
         g.assets = dict(css=['main.css'], js=['main.js'])
 
     @app.template_filter('datetime')
-    def _jinja2_filter_datetime(ts):
-        return time.strftime('%b %d, %Y %I:%M %p', time.localtime(ts))
+    def _jinja2_filter_datetime(ts, fmt=None):
+        return time.strftime(
+            fmt or app.config.get('DATETIME_FORMAT', '%b %d, %Y %I:%M %p'),
+            time.localtime(ts)
+        )
 
     @app.template_filter('b64encode')
     def _jinja2_filter_b64encode(s):


### PR DESCRIPTION
With this small patch datetimes are made customizable either in the individual templates or as a global default set by the `DATETIME_FORMAT` variable.

If the `datetime` filter is given an argument in a template, that value will be used in formatting the string. E.g.:
```html
    <td>{{ h.time|datetime('%d-%b-%Y %H:%M') }}</td>
```
could result in
```html
    <td>23-Jan-2016 12:34</td>
```
If no arguments are given, `realms-wiki` will attempt to use the formatting template from the `DATETIME_FORMAT` variable, e.g.:
```json
{
    "ALLOW_ANON": false,
    "BASE_URL": "http://localhost",
    "CACHE_TYPE": "simple",
    "DATETIME_FORMAT": "%F %T",
    "DB_URI": "sqlite:////tmp/wiki.db",
    "PORT": 5000,
    "REGISTRATION_ENABLED": true,
    "SEARCH_TYPE": "simple",
    "SECRET_KEY": "ey2hYoYyg2CeA22Q9ZX8Jcn8",
    "SITE_TITLE": "Realms",
    "WIKI_PATH": "/tmp/wiki"
}
```
could result in
```html
    <td>2016-01-23 12:34:56</td>
```
Finally, if the `DATETIME_FORMAT` variable is absent from the config, the default value of `'%b %d, %Y %I:%M %p'` is used:
```html
    <td>Jan 23, 2016 12:34 PM</td>
```
