### PR TITLE
Properly escape REALMS_WIKI_CONFIG variable

### DIFF
--- a/docker/realms-wiki.sh
+++ b/docker/realms-wiki.sh
@@ -10,7 +10,7 @@ export LC_ALL
 export GEVENT_RESOLVER
 
 if [ "${REALMS_WIKI_CONFIG}" != "" ]; then
-    realms-wiki configure ${REALMS_WIKI_CONFIG}
+    realms-wiki configure "${REALMS_WIKI_CONFIG}"
 fi
 
 if [ "${REALMS_WIKI_WORKERS}" == "" ]; then


### PR DESCRIPTION
There's a bug in realms-wiki.sh which prevents the docker image from starting correctly if REALMS_WIKI_CONFIG variable contains spaces (e.g. site title could contains spaces).