### PR TITLE
Fix wsgi relative script locations

### DIFF
--- a/realms/commands.py
+++ b/realms/commands.py
@@ -69,9 +69,9 @@ def prompt_and_invoke(ctx, fn):
 @click.option('--site-title',
               default=config.SITE_TITLE,
               prompt='Enter site title.')
-@click.option('--base_url',
-              default=config.BASE_URL,
-              prompt='Enter base URL.')
+@click.option('--url-prefix',
+              default=config.URL_PREFIX,
+              prompt='Enter URL prefix.')
 @click.option('--port',
               default=config.PORT,
               prompt='Enter port number.')

--- a/realms/config/__init__.py
+++ b/realms/config/__init__.py
@@ -75,7 +75,7 @@ SQLALCHEMY_ECHO = False
 
 HOST = "0.0.0.0"
 PORT = 5000
-BASE_URL = 'http://localhost'
+URL_PREFIX = ''
 SITE_TITLE = "Realms"
 
 # https://pythonhosted.org/Flask-SQLAlchemy/config.html#connection-uri-format
@@ -177,13 +177,8 @@ LOGIN_DISABLED = ALLOW_ANON
 # Depreciated variable name
 LOCKED = WIKI_LOCKED_PAGES[:]
 
-if BASE_URL.endswith('/'):
-    BASE_URL = BASE_URL[:-1]
-
 SQLALCHEMY_DATABASE_URI = DB_URI
 
-_url = urlparse(BASE_URL)
-RELATIVE_PATH = _url.path
 
 if in_vagrant():
     # sendfile doesn't work well with Virtualbox shared folders
@@ -197,6 +192,8 @@ if ENV != "DEV":
 MODULES = ['wiki', 'search', 'auth']
 
 globals().update(read())
+
+URL_PREFIX = URL_PREFIX.rstrip('/')
 
 if globals().get('AUTH_LOCAL_ENABLE'):
     MODULES.append('auth.local')

--- a/realms/modules/wiki/tests.py
+++ b/realms/modules/wiki/tests.py
@@ -84,6 +84,6 @@ class WikiTest(WikiBaseTest):
         self.assert_403(self.client.post(url_for('wiki.revert'), data=dict(name='test', commit=data['sha'])))
 
 
-class RelativePathTest(WikiTest):
+class URLPrefixTest(WikiTest):
     def configure(self):
-        return dict(RELATIVE_PATH='wiki')
+        return dict(URL_PREFIX='wiki')

--- a/realms/static/js/editor.js
+++ b/realms/static/js/editor.js
@@ -76,7 +76,7 @@ var deletePage = function() {
   }).done(function(data) {
     var msg = 'Deleted page: ' + pageName;
     bootbox.alert(msg, function() {
-      location.href = '/';
+      location.href = Config['RELATIVE_PATH'] + '/';
     });
   }).fail(function(data, status, error) {
     bootbox.alert('Error deleting page!');

--- a/realms/templates/layout.html
+++ b/realms/templates/layout.html
@@ -104,9 +104,7 @@
 
     <script>
       var Config = {};
-      {% for attr in ['RELATIVE_PATH'] %}
-        Config.{{ attr }} = {{ config[attr]|tojson }};
-      {% endfor %}
+      Config.RELATIVE_PATH = {{ g.relative_path|tojson }};
 
       var User = {};
       User.is_authenticated = {{ current_user.is_authenticated()|tojson }};

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -53,7 +53,7 @@
         });
         revs.reverse();
         revs = revs.join("..");
-        location.href = "{{ config.RELATIVE_PATH }}/_compare/{{ name }}/" + revs;
+        location.href = "{{ g.relative_path }}/_compare/{{ name }}/" + revs;
       });
     });
   </script>


### PR DESCRIPTION
This fixes #120.

As far as I can make it out, my current usecase, i.e. running realms-wiki under wsgi with a relative script path, was not supported by realms. This pull request add support for this usecase (and requires no user configuration).

I made some changes that are a bit opinionated:
- remove `BASE_URL` (was only used for `RELATIVE_PATH`)
- rename `RELATIVE_PATH` to `URL_PREFIX`

The current scheme is less ambiguous: `RELATIVE_PATH` is used elsewhere in the code and is not necessarily the same as `URL_PREFIX` and usages are closer to the naming in flask.

The downside: existing configurations have to be manually updated.

I'll rework the pull request if I hear objections to the renaming.
