### PR TITLE
Update README style guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ You can copy and paste into a new page for testing purposes.
 Issues and pull requests are welcome.
 Please follow the code style guide.
 
-[Python style guide](http://google-styleguide.googlecode.com/svn/trunk/pyguide.html)
+[Python style guide](https://www.python.org/dev/peps/pep-0008/)
 
 ## Author
 


### PR DESCRIPTION
The current link is a 404, and goes to google's style guide.

Google's style guide recommends pylint, which runs with 77 errors, 50
warn, 35 refactor, and 336 convention messages.

By pep8, there are 122 messages, mostly line length and imports not
being at the top of the file.

So I've made the assumption this is meant to be based on pep8 to that.