### PR TITLE
History optimization/improvement fix #149

### DIFF
--- a/realms/modules/search/commands.py
+++ b/realms/modules/search/commands.py
@@ -30,10 +30,12 @@ def rebuild_index():
                 continue
             name = filename_to_cname(page['path'])
             # TODO add email?
+            # TODO I have concens about indexing the commit info from latest revision, see #148
+            info = next(page.history)
             body = dict(name=name,
                         content=page.data,
-                        message=page.info['message'],
-                        username=page.info['author'],
+                        message=info['message'],
+                        username=info['author'],
                         updated_on=entry['mtime'],
                         created_on=entry['ctime'])
             search.index_wiki(name, body)

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -96,7 +96,7 @@ class WikiPage(object):
         if cached:
             return cached
 
-        info = self.get_history(limit=1)[0]
+        info = next(self.history)
         cache.set(cache_key, info)
         return info
 
@@ -104,10 +104,54 @@ class WikiPage(object):
     def history(self):
         """Get page history.
 
-        :return: list -- List of dicts
+        History can take a long time to generate for repositories with many commits.
+        This returns an iterator to avoid having to load them all at once.
+
+        :return: iter -- Iterator over dicts
 
         """
-        return PageHistory(self, self._cache_key('history'))
+        cache_complete = False
+        cached_revs = cache.get(self._cache_key('history')) or []
+        start_sha = None
+        if cached_revs:
+            if cached_revs[-1] == 'TAIL':
+                del cached_revs[-1]
+                cache_complete = True
+            else:
+                start_sha = cached_revs[-1]['sha']
+        for rev in cached_revs:
+            yield rev
+        if cache_complete:
+            return
+        if not len(self.wiki.repo.open_index()):
+            # Index is empty, no commits
+            return
+        walker = iter(self.wiki.repo.get_walker(paths=[self.filename], include=start_sha, follow=True))
+        if start_sha:
+            # If we are not starting from HEAD, we already have the start commit
+            next(walker)
+        filename = self.filename
+        try:
+            for entry in walker:
+                change_type = None
+                for change in entry.changes():
+                    if change.new.path == filename:
+                        filename = change.old.path
+                        change_type = change.type
+                        break
+
+                author_name, author_email = entry.commit.author.rstrip('>').split('<')
+                r = dict(author=author_name.strip(),
+                         author_email=author_email,
+                         time=entry.commit.author_time,
+                         message=entry.commit.message,
+                         sha=entry.commit.id,
+                         type=change_type)
+                cached_revs.append(r)
+                yield r
+            cached_revs.append('TAIL')
+        finally:
+            cache.set(self._cache_key('history'), cached_revs)
 
     @property
     def partials(self):
@@ -298,75 +342,3 @@ class WikiPage(object):
             # We'll get a KeyError if self.sha isn't in the repo, or if self.filename isn't in the tree of our commit
             return False
         return True
-
-
-class PageHistory(collections.Sequence):
-    """Acts like a list, but dynamically loads and caches history revisions as requested."""
-    def __init__(self, page, cache_key):
-        self.page = page
-        self.cache_key = cache_key
-        self._store = cache.get(cache_key) or []
-        if not self._store:
-            self._iter_rest = self._get_rest()
-        elif self._store[-1] == 'TAIL':
-            self._iter_rest = None
-        else:
-            self._iter_rest = self._get_rest(self._store[-1]['sha'])
-
-    def __iter__(self):
-        # Iterate over the revisions already cached
-        for r in self._store:
-            if r == 'TAIL':
-                return
-            yield r
-        # Iterate over the revisions yet to be discovered
-        if self._iter_rest:
-            try:
-                for r in self._iter_rest:
-                    self._store.append(r)
-                    yield r
-                self._store.append('TAIL')
-            finally:
-                # Make sure we cache the results whether or not the iteration was completed
-                cache.set(self.cache_key, self._store)
-
-    def _get_rest(self, start_sha=None):
-        if not len(self.page.wiki.repo.open_index()):
-            # Index is empty, no commits
-            return
-        walker = iter(self.page.wiki.repo.get_walker(paths=[self.page.filename], include=start_sha, follow=True))
-        if start_sha:
-            # If we are not starting from HEAD, we already have the start commit
-            print(next(walker))
-        filename = self.page.filename
-        for entry in walker:
-            change_type = None
-            for change in entry.changes():
-                if change.new.path == filename:
-                    filename = change.old.path
-                    change_type = change.type
-                    break
-
-            author_name, author_email = entry.commit.author.rstrip('>').split('<')
-            r = dict(author=author_name.strip(),
-                     author_email=author_email,
-                     time=entry.commit.author_time,
-                     message=entry.commit.message,
-                     sha=entry.commit.id,
-                     type=change_type)
-            yield r
-
-    def __getitem__(self, index):
-        if isinstance(index, slice):
-            return list(itertools.islice(self, index.start, index.stop, index.step))
-        else:
-            try:
-                return next(itertools.islice(self, index, index+1))
-            except StopIteration:
-                raise IndexError
-
-    def __len__(self):
-        if not self._store or self._store[-1] != 'TAIL':
-            # Force generation of all revisions
-            list(self)
-        return len(self._store) - 1  # Don't include the TAIL sentinel

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -223,7 +223,8 @@ class WikiPage(HookMixin):
         return username, email
 
     def _clear_cache(self):
-        cache.delete_many(*(self._cache_key(p) for p in ['data', 'info']))
+        for p in ['data', 'history']:
+            cache.delete(self._cache_key(p))
 
     def delete(self, username=None, email=None, message=None):
         """Delete page.

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -90,17 +90,6 @@ class WikiPage(object):
         return data
 
     @property
-    def info(self):
-        cache_key = self._cache_key('info')
-        cached = cache.get(cache_key)
-        if cached:
-            return cached
-
-        info = next(self.history)
-        cache.set(cache_key, info)
-        return info
-
-    @property
     def history(self):
         """Get page history.
 

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -143,6 +143,20 @@ class WikiPage(object):
             cache.set(self._cache_key('history'), cached_revs)
 
     @property
+    def history_cache(self):
+        """Get info about the history cache.
+
+        :return: tuple -- (cached items, cache complete?)
+        """
+        cache_complete = False
+        cached_revs = cache.get(self._cache_key('history')) or []
+        if cached_revs:
+            if cached_revs[-1] == 'TAIL':
+                del cached_revs[-1]
+                cache_complete = True
+        return len(cached_revs), cache_complete
+
+    @property
     def partials(self):
         data = self.data
         if not data:

--- a/realms/modules/wiki/tests.py
+++ b/realms/modules/wiki/tests.py
@@ -41,7 +41,7 @@ class WikiTest(WikiBaseTest):
         self.assert_200(rv)
 
         self.assert_context('name', 'test')
-        eq_(self.get_context_variable('page').info['message'], 'test message')
+        eq_(next(self.get_context_variable('page').history)['message'], 'test message')
         eq_(self.get_context_variable('page').data, 'testing')
 
     def test_history(self):

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -64,14 +64,14 @@ def revert():
 def history(name):
     if current_app.config.get('PRIVATE_WIKI') and current_user.is_anonymous():
         return current_app.login_manager.unauthorized()
-    ITEMS_PER_PAGE = 15
+    items_per_page = 15
     page = int(request.args.get('page', 1))
-    start_index = (page - 1) * ITEMS_PER_PAGE
-    hist = g.current_wiki.get_page(name).get_history()
+    start_index = (page - 1) * items_per_page
+    hist = g.current_wiki.get_page(name).history
     # Grab one extra item to see if there is a next page
-    items = hist[start_index:start_index+ITEMS_PER_PAGE+1]
+    items = list(itertools.islice(hist, start_index, start_index+items_per_page+1))
     more = False
-    if len(items) > ITEMS_PER_PAGE:
+    if len(items) > items_per_page:
         more = True
         items.pop()
     if page > 1 and not items:

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -28,7 +28,7 @@ def compare(name, fsha, dots, lsha):
     if current_app.config.get('PRIVATE_WIKI') and current_user.is_anonymous():
         return current_app.login_manager.unauthorized()
 
-    diff = g.current_wiki.get_page(name, sha=lsha).compare(fsha)
+    diff = g.current_wiki.get_page(name, sha=fsha).compare(lsha)
     return render_template('wiki/compare.html',
                            name=name, diff=diff, old=fsha, new=lsha)
 
@@ -79,6 +79,7 @@ def history_data(name):
     items = list(itertools.islice(page.history, start, start + length))
     for item in items:
         item['gravatar'] = gravatar_url(item['author_email'])
+        item['DT_RowId'] = item['sha']
     total_records, hist_complete = page.history_cache
     if not hist_complete:
         # Force datatables to fetch more data when it gets to the end

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -88,7 +88,8 @@ def history_data(name):
         'draw': draw,
         'recordsTotal': total_records,
         'recordsFiltered': total_records,
-        'data': items
+        'data': items,
+        'fully_loaded': hist_complete
     }
 
 

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -28,7 +28,7 @@ def compare(name, fsha, dots, lsha):
     if current_app.config.get('PRIVATE_WIKI') and current_user.is_anonymous():
         return current_app.login_manager.unauthorized()
 
-    diff = g.current_wiki.get_page(name, sha=fsha).compare(lsha)
+    diff = g.current_wiki.get_page(name, sha=lsha).compare(fsha)
     return render_template('wiki/compare.html',
                            name=name, diff=diff, old=fsha, new=lsha)
 

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -75,7 +75,7 @@ def history(name):
         more = True
         items.pop()
     if page > 1 and not items:
-        abort(404)
+        abort(404, 'Page is past end of history.')
     for item in items:
         item['gravatar'] = gravatar_url(item['author_email'])
     return render_template('wiki/history.html', name=name, history=items,

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -1,5 +1,6 @@
 import itertools
 import sys
+from datetime import datetime
 from flask import abort, g, render_template, request, redirect, Blueprint, flash, url_for, current_app
 from flask.ext.login import login_required, current_user
 from realms.lib.util import to_canonical, remove_ext, gravatar_url
@@ -80,6 +81,8 @@ def history_data(name):
     for item in items:
         item['gravatar'] = gravatar_url(item['author_email'])
         item['DT_RowId'] = item['sha']
+        date = datetime.fromtimestamp(item['time'])
+        item['date'] = date.strftime(current_app.config.get('DATETIME_FORMAT', '%b %d, %Y %I:%M %p'))
     total_records, hist_complete = page.history_cache
     if not hist_complete:
         # Force datatables to fetch more data when it gets to the end

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -83,6 +83,7 @@ def history_data(name):
         item['DT_RowId'] = item['sha']
         date = datetime.fromtimestamp(item['time'])
         item['date'] = date.strftime(current_app.config.get('DATETIME_FORMAT', '%b %d, %Y %I:%M %p'))
+        item['link'] = url_for('.commit', name=name, sha=item['sha'])
     total_records, hist_complete = page.history_cache
     if not hist_complete:
         # Force datatables to fetch more data when it gets to the end

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -96,7 +96,8 @@ def edit(name):
     return render_template('wiki/edit.html',
                            name=cname,
                            content=page.data,
-                           info=page.info,
+                           # TODO: Remove this? See #148
+                           info=next(page.history),
                            sha=page.sha,
                            partials=page.partials)
 

--- a/realms/templates/errors/404.html
+++ b/realms/templates/errors/404.html
@@ -2,5 +2,8 @@
 {% block body %}
 
   <h1>Page Not Found</h1>
+  {% if error is defined %}
+  <h4>{{ error.description }}</h4>
+  {% endif %}
 
 {% endblock %}

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -14,6 +14,9 @@
       <th>Date</th>
     </tr>
     </thead>
+    <tbody>
+    <tr><td colspan="3" style="text-align: center">Loading file history...</td></tr>
+    </tbody>
   </table>
   <p>
     <a class="btn btn-default btn-sm compare-revisions">Compare Revisions</a>

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -6,49 +6,14 @@
     <a class="btn btn-default btn-sm compare-revisions">Compare Revisions</a>
   </p>
 
-  <table class="table table-bordered revision-tbl">
+  <table class="table table-bordered revision-tbl data-table">
     <thead>
     <tr>
-      <th></th>
       <th>Name</th>
       <th>Revision Message</th>
       <th>Date</th>
     </tr>
     </thead>
-    {% if pagination.page > 1 or pagination.more %}
-      <tfoot>
-      <tr><td colspan="4">
-      <ul class="pagination" style="float: right">
-        <li class="paginate_button previous{% if pagination.page == 1 %} disabled{% endif %}">
-          <a href="{{ url_for('.history', name=name, page=pagination.page - 1) }}">Previous</a>
-        </li>
-        {% for p in range(1, pagination.page + 1) %}
-          <li class="paginate_button{% if p ==  pagination.page %} active{% endif %}">
-            <a href="{{ url_for('.history', name=name, page=p) }}">{{ p }}</a>
-          </li>
-        {% endfor %}
-        {% if pagination.more %}<li class="paginate_button disabled"><a>…</a></li>{% endif %}
-        <li class="paginate_button next{% if not pagination.more %} disabled{% endif %}">
-          <a href="{{ url_for('.history', name=name, page=pagination.page + 1) }}">Next</a>
-        </li>
-      </ul>
-      </td></tr>
-      </tfoot>
-    {% endif %}
-    <tbody>
-    {% for h in history %}
-      <tr>
-        <td class="checkbox-cell text-center">
-          {% if h.type != 'delete' %}
-          <input type="checkbox" name="versions[]" value="{{ h.sha }}" />
-          {% endif %}
-        </td>
-        <td><img src="{{ h.gravatar }}?s=20" class="avatar"/> {{ h.author }}</td>
-        <td><a href="{{ url_for('wiki.commit', name=name, sha=h.sha) }}" class='label label-primary'>View</a> {{ h.message }} </td>
-        <td>{{ h.time|datetime }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
   </table>
   <p>
     <a class="btn btn-default btn-sm compare-revisions">Compare Revisions</a>
@@ -58,6 +23,24 @@
 
 {% block js %}
   <script>
+    $(document).ready(function() {
+      $('.data-table').dataTable({
+        serverSide: true,
+        ajax: '{{ url_for('.history_data', name=name) }}',
+        ordering: false,
+        bFilter: false,
+        columns: [
+          { "data": "author" },
+          { "data": "message" },
+          { "data": "time",
+            "render": function (data) {
+              var date = new Date(0);
+              date.setUTCSeconds(data)
+              return date.toDateString();
+            }}
+        ]
+      });
+    });
     $(function(){
       $('.revision-tbl :checkbox').change(function () {
         var $cs=$(this).closest('.revision-tbl').find(':checkbox:checked');

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -58,7 +58,11 @@
         ordering: false,
         bFilter: false,
         columns: [
-          { "data": "author" },
+          { "data": null,
+            "render": function(data) {
+              return '<img src="' + data.gravatar + '?s=20" class="avatar" /> ' + data.author
+            }
+          },
           { "data": "message" },
           { "data": "time",
             "render": function (data) {

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -45,7 +45,13 @@
 
       $('.dataTable').dataTable({
         serverSide: true,
-        ajax: '{{ url_for('.history_data', name=name) }}',
+        ajax: {
+          url: '{{ url_for('.history_data', name=name) }}',
+          dataSrc: function (data) {
+            $('.dataTable').data('fully_loaded', data.fully_loaded);
+            return data.data
+          }
+        },
         ordering: false,
         bFilter: false,
         columns: [
@@ -64,6 +70,12 @@
             if ( $.inArray(data.DT_RowId, selected) !== -1 ) {
                 $(row).addClass('active');
             }
+        },
+        infoCallback: function( settings, start, end, max, total, pre ) {
+          if (!$('.dataTable').data('fully_loaded')) {
+            total += "+"
+          }
+          return "Showing " + start +" to "+ end + " of " + total + " revisions.";
         }
       });
 

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -6,7 +6,7 @@
     <a class="btn btn-default btn-sm compare-revisions">Compare Revisions</a>
   </p>
 
-  <table class="table table-bordered revision-tbl data-table">
+  <table class="table table-bordered revision-tbl dataTable DTTT_selectable">
     <thead>
     <tr>
       <th>Name</th>
@@ -21,10 +21,29 @@
 
 {% endblock %}
 
+{% block css %}
+  <style type="text/css">
+    table.dataTable td {
+      transition: background-color 0.5s linear, color 0.5s linear;
+      transition-delay: 0.1s;
+    }
+    table.dataTable tr.active td {
+      transition: background-color 0.1s linear, color 0.1s linear;
+      transition-delay: 0s
+    }
+    table.dataTable tbody tr:hover {
+      background-color: #d8d8d8 !important;
+    }
+  </style>
+{% endblock %}
+
 {% block js %}
   <script>
     $(document).ready(function() {
-      $('.data-table').dataTable({
+      var selected = [];
+      var selected_pos = [];
+
+      $('.dataTable').dataTable({
         serverSide: true,
         ajax: '{{ url_for('.history_data', name=name) }}',
         ordering: false,
@@ -38,26 +57,42 @@
               return date.toDateString();
             }
           }
-        ]
-      });
-    });
-    $(function(){
-      $('.revision-tbl :checkbox').change(function () {
-        var $cs=$(this).closest('.revision-tbl').find(':checkbox:checked');
-        if ($cs.length > 2) {
-          this.checked=false;
+        ],
+        rowCallback: function( row, data, index ) {
+            index += $('.dataTable').DataTable().page.info().start;
+            $(row).data('index', index);
+            if ( $.inArray(data.DT_RowId, selected) !== -1 ) {
+                $(row).addClass('active');
+            }
         }
       });
 
+      $('.dataTable tbody').on('click', 'tr', function () {
+        var id = this.id;
+        var selected_index = $.inArray(id, selected);
+
+        if ( selected_index === -1 ) {
+            selected.push( id );
+            selected_pos.push( $(this).data('index') );
+            if ( selected.length > 2) {
+                // Only 2 selected at once
+                var shifted = selected.shift();
+                selected_pos.shift();
+                $('#' + shifted).removeClass('active');
+            }
+        } else {
+            selected.splice( selected_index, 1 );
+            selected_pos.splice( selected_index, 1);
+        }
+
+        $(this).toggleClass('active');
+      });
       $(".compare-revisions").click(function(){
-        var $cs = $('.revision-tbl').find(':checkbox:checked');
-        if ($cs.length != 2) return;
-        var revs = [];
-        $.each($cs, function(i, v){
-          revs.push(v.value);
-        });
-        revs.reverse();
-        revs = revs.join("..");
+        if (selected.length != 2) return;
+        if (selected_pos[1] > selected_pos[0]) {
+          selected.reverse()
+        }
+        revs = selected.join("..");
         location.href = "{{ config.RELATIVE_PATH }}/_compare/{{ name }}/" + revs;
       });
     });

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -28,6 +28,22 @@
       </tr>
     {% endfor %}
   </table>
+  <!-- TODO: make this pagination look good -->
+  {% if pagination.page > 1 or pagination.more %}
+    <div>
+      {% if pagination.page > 1 %}
+        <a href="{{ url_for('.history', name=name, page=pagination.page - 1) }}">&lt;</a>
+      {% else %}
+        &lt;
+      {% endif %}
+      {{ pagination.page }}
+      {% if pagination.more %}
+        <a href="{{ url_for('.history', name=name, page=pagination.page + 1) }}">&gt;</a>
+      {% else %}
+        &gt;
+      {% endif %}
+    </div>
+  {% endif %}
   <p>
     <a class="btn btn-default btn-sm compare-revisions">Compare Revisions</a>
   </p>

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -34,10 +34,10 @@
           { "data": "message" },
           { "data": "time",
             "render": function (data) {
-              var date = new Date(0);
-              date.setUTCSeconds(data)
+              var date = new Date(data * 1000);
               return date.toDateString();
-            }}
+            }
+          }
         ]
       });
     });

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -64,12 +64,7 @@
             }
           },
           { "data": "message" },
-          { "data": "time",
-            "render": function (data) {
-              var date = new Date(data * 1000);
-              return date.toDateString();
-            }
-          }
+          { "data": "date" }
         ],
         rowCallback: function( row, data, index ) {
             index += $('.dataTable').DataTable().page.info().start;

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -58,12 +58,18 @@
         ordering: false,
         bFilter: false,
         columns: [
-          { "data": null,
-            "render": function(data) {
-              return '<img src="' + data.gravatar + '?s=20" class="avatar" /> ' + data.author
+          {
+            "data": null,
+            "render": function (data) {
+              return '<img src="' + data.gravatar + '?s=20" class="avatar" />&nbsp;&nbsp;' + data.author
             }
           },
-          { "data": "message" },
+          {
+            "data": null,
+            "render": function (data) {
+              return '<a href="' + data.link + '" class="label label-primary">View</a>&nbsp;&nbsp;' + data.message
+            }
+          },
           { "data": "date" }
         ],
         rowCallback: function( row, data, index ) {

--- a/realms/templates/wiki/history.html
+++ b/realms/templates/wiki/history.html
@@ -15,6 +15,27 @@
       <th>Date</th>
     </tr>
     </thead>
+    {% if pagination.page > 1 or pagination.more %}
+      <tfoot>
+      <tr><td colspan="4">
+      <ul class="pagination" style="float: right">
+        <li class="paginate_button previous{% if pagination.page == 1 %} disabled{% endif %}">
+          <a href="{{ url_for('.history', name=name, page=pagination.page - 1) }}">Previous</a>
+        </li>
+        {% for p in range(1, pagination.page + 1) %}
+          <li class="paginate_button{% if p ==  pagination.page %} active{% endif %}">
+            <a href="{{ url_for('.history', name=name, page=p) }}">{{ p }}</a>
+          </li>
+        {% endfor %}
+        {% if pagination.more %}<li class="paginate_button disabled"><a>…</a></li>{% endif %}
+        <li class="paginate_button next{% if not pagination.more %} disabled{% endif %}">
+          <a href="{{ url_for('.history', name=name, page=pagination.page + 1) }}">Next</a>
+        </li>
+      </ul>
+      </td></tr>
+      </tfoot>
+    {% endif %}
+    <tbody>
     {% for h in history %}
       <tr>
         <td class="checkbox-cell text-center">
@@ -27,23 +48,8 @@
         <td>{{ h.time|datetime }}</td>
       </tr>
     {% endfor %}
+    </tbody>
   </table>
-  <!-- TODO: make this pagination look good -->
-  {% if pagination.page > 1 or pagination.more %}
-    <div>
-      {% if pagination.page > 1 %}
-        <a href="{{ url_for('.history', name=name, page=pagination.page - 1) }}">&lt;</a>
-      {% else %}
-        &lt;
-      {% endif %}
-      {{ pagination.page }}
-      {% if pagination.more %}
-        <a href="{{ url_for('.history', name=name, page=pagination.page + 1) }}">&gt;</a>
-      {% else %}
-        &gt;
-      {% endif %}
-    </div>
-  {% endif %}
   <p>
     <a class="btn btn-default btn-sm compare-revisions">Compare Revisions</a>
   </p>


### PR DESCRIPTION
This addresses most of the concerns from #149. It makes a `WikiPage.history` property, which is an iterator rather than a list. This means thing using the property, like the history view, can use itertools.islice or similar methods to only load up to a certain point. I've also added `WikiPage.history_cache`, which returns the number of cached items in history, as well as whether the cache is complete. Not super nice, but that info is needed to get good paging functionality in the history view. I've also removed the info property, with reasoning from #148. I didn't delete the usages of it from search indexer or edit page view, which I think should probably also go.

I redid the history view to use datatables, which gets the data via ajax calls. When the history hasn't been fully cached, the data provider will return that there is one more entry available, which means the first time you page through a pages history, the page count grows as you go to each next page. This also eliminates the hard coded 100 revision limit previously imposed on history view.
Some points to think about still, and stuff yet to finish:
- [x] Add the gravatar back to the author column
- [x] Add back ability to select revisions and initiate a comparison.
- [x] Re-add button to view at given revision.
- [x] Make date format more consistent with index view?
- [x] When the cache isn't complete the reported total records is one more than we have cached. Perhaps just change that to have a + or something e.g. `Showing 31 to 40 of 41+ entries`
- ~~Along the same lines, maybe add an ellipsis at the end of the page buttons to indicate there might be more.~~ 
- ~~When cache isn't complete, add an 'End' button to the page controls to force loading of all revisions.~~ Editing the paging buttons dynamically seem more complicated than it's worth

EDIT: I think this is good to go now
Improvement/change summary:
- History is only calculated for requested items
- Calculated history is now cached
- History cache saved even when updating or renaming a page
- History view is paged, and requests each page via ajax
- History view is not limited to 100 items
- Whole line is selectable rather than checkboxes
- Only 2 lines are selectable at a time to compare, selecting another will deselect the first revision selected.