### PR TITLE
Cause an error when trying to hook invalid HookMixin method

### DIFF
--- a/realms/lib/hook.py
+++ b/realms/lib/hook.py
@@ -25,9 +25,12 @@ class HookMixinMeta(type):
     def __new__(cls, name, bases, attrs):
         super_new = super(HookMixinMeta, cls).__new__
 
+        hookable = []
         for key, value in attrs.items():
             if callable(value):
                 attrs[key] = hook_func(key, value)
+                hookable.append(key)
+        attrs['_hookable'] = hookable
 
         return super_new(cls, name, bases, attrs)
 
@@ -37,9 +40,12 @@ class HookMixin(object):
 
     _pre_hooks = {}
     _post_hooks = {}
+    _hookable = []
 
     @classmethod
     def after(cls, method_name):
+        assert method_name in cls._hookable, "'%s' not a hookable method of '%s'" % (method_name, cls.__name__)
+
         def outer(f, *args, **kwargs):
             cls._post_hooks.setdefault(method_name, []).append((f, args, kwargs))
             return f
@@ -47,6 +53,8 @@ class HookMixin(object):
 
     @classmethod
     def before(cls, method_name):
+        assert method_name in cls._hookable, "'%s' not a hookable method of '%s'" % (method_name, cls.__name__)
+
         def outer(f, *args, **kwargs):
             cls._pre_hooks.setdefault(method_name, []).append((f, args, kwargs))
             return f

--- a/realms/lib/hook.py
+++ b/realms/lib/hook.py
@@ -27,6 +27,9 @@ class HookMixinMeta(type):
 
         hookable = []
         for key, value in attrs.items():
+            # Disallow hooking methods which start with an underscore (allow __init__ etc. still)
+            if key.startswith('_') and not key.startswith('__'):
+                continue
             if callable(value):
                 attrs[key] = hook_func(key, value)
                 hookable.append(key)


### PR DESCRIPTION
Just causes an error if you try to hook something non-supported by an `HookMixin` subclass. Shouldn't ever happen at runtime, but will make programming errors more visible. I accidentally broke the search module `Wiki` hooks when moving stuff to `WikiPage`, and thought this would be helpful to make that sort of thing more noticable.