### PR TITLE
[WIP] Sync module to push/pull changes from remote repo

### DIFF
--- a/realms/config/__init__.py
+++ b/realms/config/__init__.py
@@ -112,6 +112,16 @@ class Config(object):
 
     ROOT_ENDPOINT = 'wiki.page'
 
+    # Sync module settings
+    # Repo to push and pull from
+    SYNC_REPO = ''
+    # Gittle auth parameters. username, password, pkey, look_for_key, allow_agent
+    SYNC_AUTH = {}
+    # Enable pushing to SYNC_REPO on each wiki commit
+    SYNC_PUSH = True
+    # Enable github webhook endpoint to pull
+    SYNC_PULL = False
+
     # Used by Flask-Login
     @property
     def LOGIN_DISABLED(self):

--- a/realms/modules/sync/hooks.py
+++ b/realms/modules/sync/hooks.py
@@ -1,0 +1,10 @@
+from realms.config import conf
+from realms.modules.wiki.models import Wiki
+
+
+@Wiki.after('commit')
+def sync_push(wiki, *args, **kwargs):
+    wiki.gittle.auth(conf.SYNC_AUTH)
+    if not conf.SYNC_PUSH:
+        return
+    wiki.gittle.push_to(conf.SYNC_REPO)

--- a/realms/modules/sync/views.py
+++ b/realms/modules/sync/views.py
@@ -1,0 +1,14 @@
+from flask import g, Blueprint
+from realms.config import conf
+
+blueprint = Blueprint('sync', __name__)
+
+
+@blueprint.route('/_sync/webhook')
+def sync_webhook():
+    """Receives a github webhook, and causes new changes to be pulled."""
+    if not conf.SYNC_PULL:
+        return
+    # TODO: Check this is a post-receive on the correct repo?
+    g.current_wiki.gittle.auth(conf.SYNC_AUTH)
+    g.current_wiki.gittle.pull_from(conf.SYNC_REPO)


### PR DESCRIPTION
This is the start of a `sync` module, which can push and pull changes from a remote repo. This would allow e.g. keeping a github mirror up to date with realms changes, and/or automatically pulling changes from a remote (like if you merge a PR from github.)

I haven't actually tested anything yet, just posting PR now for discussion/status updates.

Things to do:
- [ ] verify it doesn't work yet
- [ ] make it work
- [ ] allow setting the branch of the remote repo
- [ ] validate the github hook payload is actually about the repo/branch we care about
- [ ] Support webhooks from other services?
- [ ] It looks like Gittle.pull ignores the branch_name arg and only does a fetch. Investigate dulwich.porcelain
- [ ] What to do if there are conflicts when pushing/pulling?