### PR TITLE
Fix CLI registration for module command groups. fix #103

### DIFF
--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -1,3 +1,4 @@
+import functools
 import sys
 
 # Set default encoding to UTF-8
@@ -75,7 +76,9 @@ class Application(Flask):
 
             # Click
             if hasattr(sources, 'commands'):
-                cli.add_command(sources.commands.cli, name=module_name)
+                if sources.commands.cli.name == 'cli':
+                    sources.commands.cli.name = module_name
+                cli.add_command(sources.commands.cli)
 
             # Hooks
             if hasattr(sources, 'hooks'):
@@ -287,9 +290,8 @@ class AppGroup(click.Group):
         kwargs.setdefault('cls', AppGroup)
         return click.Group.group(self, *args, **kwargs)
 
-flask_cli = AppGroup()
+cli = AppGroup()
 
+# Decorator to be used in modules instead of click.group
+cli_group = functools.partial(click.group, cls=AppGroup)
 
-@flask_cli.group()
-def cli():
-    pass

--- a/realms/commands.py
+++ b/realms/commands.py
@@ -1,4 +1,4 @@
-from realms import config, create_app, db, __version__, flask_cli as cli, cache
+from realms import config, create_app, db, __version__, cli, cache
 from realms.lib.util import random_string, in_virtualenv, green, yellow, red
 from subprocess import call, Popen
 from multiprocessing import cpu_count

--- a/realms/modules/auth/local/commands.py
+++ b/realms/modules/auth/local/commands.py
@@ -2,10 +2,10 @@ import click
 from realms.lib.util import random_string
 from realms.modules.auth.local.models import User
 from realms.lib.util import green, red, yellow
-from realms import flask_cli
+from realms import cli_group
 
 
-@flask_cli.group(short_help="Auth Module")
+@cli_group(short_help="Auth Module")
 def cli():
     pass
 

--- a/realms/modules/search/commands.py
+++ b/realms/modules/search/commands.py
@@ -1,10 +1,10 @@
 import click
-from realms import create_app, search, flask_cli
+from flask import current_app
+from realms import search, cli_group
 from realms.modules.wiki.models import Wiki
-from realms.lib.util import filename_to_cname
 
 
-@flask_cli.group(short_help="Search Module")
+@cli_group(short_help="Search Module")
 def cli():
     pass
 
@@ -13,27 +13,23 @@ def cli():
 def rebuild_index():
     """ Rebuild search index
     """
-    app = create_app()
-
-    if app.config.get('SEARCH_TYPE') == 'simple':
+    if current_app.config.get('SEARCH_TYPE') == 'simple':
         click.echo("Search type is simple, try using elasticsearch.")
         return
 
-    with app.app_context():
-        # Wiki
-        search.delete_index('wiki')
-        wiki = Wiki(app.config['WIKI_PATH'])
-        for entry in wiki.get_index():
-            page = wiki.get_page(entry['name'])
-            if not page:
-                # Some non-markdown files may have issues
-                continue
-            name = filename_to_cname(page['path'])
-            # TODO add email?
-            body = dict(name=name,
-                        content=page.data,
-                        message=page.info['message'],
-                        username=page.info['author'],
-                        updated_on=entry['mtime'],
-                        created_on=entry['ctime'])
-            search.index_wiki(name, body)
+    # Wiki
+    search.delete_index('wiki')
+    wiki = Wiki(current_app.config['WIKI_PATH'])
+    for entry in wiki.get_index():
+        page = wiki.get_page(entry['name'])
+        if not page:
+            # Some non-markdown files may have issues
+            continue
+        # TODO add email?
+        body = dict(name=page.name,
+                    content=page.data,
+                    message=page.info['message'],
+                    username=page.info['author'],
+                    updated_on=entry['mtime'],
+                    created_on=entry['ctime'])
+        search.index_wiki(name, body)


### PR DESCRIPTION
It seems commands registered by submodules got a little bit borked by bd41eaac4ef9b8e154558cfa7993f0d46acdb434 Instead of modules creating click groups that later got registered, they started calling the AppGroup().group method, which already registered them under the 'cli' subcommand name, and each successive module cli command would overwrite the last.

I wasn't sure the way we wanted to solve it, but I figured we didn't want the modules just auto-registering themselves on import (do we?) I made a `realms.cli_group` decorator that modules can use to declare create their command group (like the `click.group` function, but sets `cls=AppGroup`,) and then the application registers the command during discovery phase. Since the context is now being opened externally, I also stripped that bit out of search's rebuild_index command. I also added the ability for modules to declare a CLI group name different than their module name if desired.