### PR TITLE
Use github's anonymous email when github auth user has private email

### DIFF
--- a/realms/modules/auth/oauth/models.py
+++ b/realms/modules/auth/oauth/models.py
@@ -40,7 +40,7 @@ providers = {
         'field_map': {
             'id': 'id',
             'username': 'login',
-            'email': 'email'
+            'email': lambda(data): data.get('email') or data['login'] + '@users.noreply.github.com'
         },
         'token_name': 'access_token'
     },
@@ -118,6 +118,8 @@ class User(BaseUser):
         def get_value(d, key):
             if isinstance(key, basestring):
                 return d.get(key)
+            elif callable(key):
+                return key(d)
             # key should be list here
             val = d.get(key.pop(0))
             if len(key) == 0:


### PR DESCRIPTION
Github has an option to keep your email address private. When an user logs in via github oauth, currently all of their edits will have anon@anon.anon email. When viewing the wiki repo history in github this all gets interpreted as one user. This commit sets the email for github users with private email addresses to `<username>@users.noreply.github.com`, which github recognizes as belonging to the proper user.

Instead of making conditionals in the class, I just added the ability for the field maps to contain lambda functions.