### PR TITLE
systematic use of `from __future__ import absolute_import`

### DIFF
--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import functools
 import sys
 
@@ -9,8 +11,10 @@ sys.setdefaultencoding('utf-8')
 import base64
 import time
 import json
-import httplib
 import traceback
+import six.moves.http_client as httplib
+from functools import update_wrapper
+
 import click
 from flask import Flask, request, render_template, url_for, redirect, g
 from flask_cache import Cache
@@ -18,7 +22,6 @@ from flask_login import LoginManager, current_user
 from flask_sqlalchemy import SQLAlchemy
 from flask_assets import Environment, Bundle
 from flask_ldap_login import LDAPLoginManager
-from functools import update_wrapper
 from werkzeug.routing import BaseConverter
 from werkzeug.exceptions import HTTPException
 from sqlalchemy.ext.declarative import declarative_base

--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import
 
-import functools
 import sys
-
 # Set default encoding to UTF-8
 reload(sys)
 # noinspection PyUnresolvedReferences
 sys.setdefaultencoding('utf-8')
 
+import functools
 import base64
 import time
 import json
@@ -26,11 +25,11 @@ from werkzeug.routing import BaseConverter
 from werkzeug.exceptions import HTTPException
 from sqlalchemy.ext.declarative import declarative_base
 
-from .modules.search.models import Search
-from .lib.util import to_canonical, remove_ext, mkdir_safe, gravatar_url, to_dict
-from .lib.hook import HookModelMeta, HookMixin
-from .lib.util import is_su, in_virtualenv
-from .version import __version__
+from realms.modules.search.models import Search
+from realms.lib.util import to_canonical, remove_ext, mkdir_safe, gravatar_url, to_dict
+from realms.lib.hook import HookModelMeta, HookMixin
+from realms.lib.util import is_su, in_virtualenv
+from realms.version import __version__
 
 
 class Application(Flask):

--- a/realms/commands.py
+++ b/realms/commands.py
@@ -11,8 +11,8 @@ from multiprocessing import cpu_count
 import click
 import pip
 
-from . import config, create_app, db, __version__, cli, cache
-from .lib.util import random_string, in_virtualenv, green, yellow, red
+from realms import config, create_app, db, __version__, cli, cache
+from realms.lib.util import random_string, in_virtualenv, green, yellow, red
 
 config = config.conf
 

--- a/realms/commands.py
+++ b/realms/commands.py
@@ -14,7 +14,9 @@ import pip
 from realms import config, create_app, db, __version__, cli, cache
 from realms.lib.util import random_string, in_virtualenv, green, yellow, red
 
+
 config = config.conf
+
 
 # called to discover commands in modules
 app = create_app()

--- a/realms/commands.py
+++ b/realms/commands.py
@@ -1,14 +1,18 @@
-from realms import config, create_app, db, __version__, cli, cache
-from realms.lib.util import random_string, in_virtualenv, green, yellow, red
-from subprocess import call, Popen
-from multiprocessing import cpu_count
-import click
+from __future__ import absolute_import
+
 import json
 import sys
 import os
-import pip
 import time
 import subprocess
+from subprocess import call, Popen
+from multiprocessing import cpu_count
+
+import click
+import pip
+
+from . import config, create_app, db, __version__, cli, cache
+from .lib.util import random_string, in_virtualenv, green, yellow, red
 
 config = config.conf
 

--- a/realms/config/__init__.py
+++ b/realms/config/__init__.py
@@ -4,9 +4,10 @@ import json
 import os
 import sys
 
+# noinspection PyUnresolvedReferences
 from six.moves.urllib.parse import urlparse
 
-from ..lib.util import in_vagrant
+from realms.lib.util import in_vagrant
 
 
 class Config(object):

--- a/realms/config/__init__.py
+++ b/realms/config/__init__.py
@@ -75,7 +75,7 @@ class Config(object):
 
     CACHE_MEMCACHED_SERVERS = ['127.0.0.1:11211']
 
-    # Valid options: simple, elasticsearch, woosh
+    # Valid options: simple, elasticsearch, whoosh
     SEARCH_TYPE = 'simple'
 
     ELASTICSEARCH_URL = 'http://127.0.0.1:9200'

--- a/realms/config/__init__.py
+++ b/realms/config/__init__.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
+
 import json
 import os
 import sys
-from urlparse import urlparse
 
-from realms.lib.util import in_vagrant
+from six.moves.urllib.parse import urlparse
+
+from ..lib.util import in_vagrant
 
 
 class Config(object):

--- a/realms/lib/__init__.py
+++ b/realms/lib/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import absolute_import
+

--- a/realms/lib/hook.py
+++ b/realms/lib/hook.py
@@ -1,6 +1,9 @@
-from flask_sqlalchemy import DeclarativeMeta
+from __future__ import absolute_import
 
 from functools import wraps
+
+from flask_sqlalchemy import DeclarativeMeta
+
 
 
 def hook_func(name, fn):

--- a/realms/lib/model.py
+++ b/realms/lib/model.py
@@ -1,7 +1,11 @@
+from __future__ import absolute_import
+
 import json
-from sqlalchemy import not_, and_
 from datetime import datetime
-from realms import db
+
+from sqlalchemy import not_, and_
+
+from .. import db
 
 
 class Model(db.Model):

--- a/realms/lib/model.py
+++ b/realms/lib/model.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from sqlalchemy import not_, and_
 
-from .. import db
+from realms import db
 
 
 class Model(db.Model):

--- a/realms/lib/test.py
+++ b/realms/lib/test.py
@@ -6,8 +6,8 @@ import tempfile
 
 from flask_testing import TestCase
 
-from realms.lib.util import random_string
 from realms import create_app
+from realms.lib.util import random_string
 
 
 class BaseTest(TestCase):

--- a/realms/lib/test.py
+++ b/realms/lib/test.py
@@ -1,7 +1,11 @@
+from __future__ import absolute_import
+
 import os
 import shutil
 import tempfile
+
 from flask_testing import TestCase
+
 from realms.lib.util import random_string
 from realms import create_app
 

--- a/realms/lib/util.py
+++ b/realms/lib/util.py
@@ -1,4 +1,5 @@
-import click
+from __future__ import absolute_import
+
 import re
 import os
 import hashlib
@@ -6,6 +7,8 @@ import json
 import string
 import random
 import sys
+
+import click
 from jinja2 import Template
 
 

--- a/realms/modules/__init__.py
+++ b/realms/modules/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/realms/modules/auth/__init__.py
+++ b/realms/modules/auth/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from flask import request, flash, redirect
 from flask_login import login_url
 
-from ... import login_manager
+from realms import login_manager
 
 modules = set()
 

--- a/realms/modules/auth/__init__.py
+++ b/realms/modules/auth/__init__.py
@@ -1,6 +1,9 @@
-from realms import login_manager
+from __future__ import absolute_import
+
 from flask import request, flash, redirect
 from flask_login import login_url
+
+from ... import login_manager
 
 modules = set()
 

--- a/realms/modules/auth/ldap/__init__.py
+++ b/realms/modules/auth/ldap/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from ..models import Auth
 
 Auth.register('ldap')

--- a/realms/modules/auth/ldap/__init__.py
+++ b/realms/modules/auth/ldap/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
 
-from ..models import Auth
+from realms.modules.auth.models import Auth
 
 Auth.register('ldap')

--- a/realms/modules/auth/ldap/forms.py
+++ b/realms/modules/auth/ldap/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from flask_wtf import Form
 from wtforms import StringField, PasswordField, validators
 

--- a/realms/modules/auth/ldap/models.py
+++ b/realms/modules/auth/ldap/models.py
@@ -5,7 +5,7 @@ from flask_login import login_user
 from flask_ldap_login import LDAPLoginForm
 
 from realms import ldap
-from ..models import BaseUser
+from realms.modules.auth.models import BaseUser
 
 
 users = {}

--- a/realms/modules/auth/ldap/models.py
+++ b/realms/modules/auth/ldap/models.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+
 from flask import render_template
 from flask_login import login_user
-from realms import ldap
 from flask_ldap_login import LDAPLoginForm
+
+from realms import ldap
 from ..models import BaseUser
 
 

--- a/realms/modules/auth/ldap/views.py
+++ b/realms/modules/auth/ldap/views.py
@@ -1,6 +1,14 @@
+<<<<<<< HEAD
 from flask import current_app, request, redirect, Blueprint, flash, url_for, session
 from ..ldap.models import User
+=======
+from __future__ import absolute_import
+
+from flask import current_app, request, redirect, Blueprint, flash, url_for
+>>>>>>> systematic use of `from __future__ import absolute_import`. it eliminates `import NAME` confusion with very common names (eg. `import ldap` is very ambiguous: can be a ldap module from realms-wiki, a ldap module from flask-ldap-login, or `python-ldap` module.
 from flask_ldap_login import LDAPLoginForm
+
+from .models import User
 
 blueprint = Blueprint('auth.ldap', __name__)
 

--- a/realms/modules/auth/ldap/views.py
+++ b/realms/modules/auth/ldap/views.py
@@ -1,14 +1,10 @@
-<<<<<<< HEAD
-from flask import current_app, request, redirect, Blueprint, flash, url_for, session
-from ..ldap.models import User
-=======
 from __future__ import absolute_import
 
-from flask import current_app, request, redirect, Blueprint, flash, url_for
->>>>>>> systematic use of `from __future__ import absolute_import`. it eliminates `import NAME` confusion with very common names (eg. `import ldap` is very ambiguous: can be a ldap module from realms-wiki, a ldap module from flask-ldap-login, or `python-ldap` module.
+from flask import current_app, request, redirect, Blueprint, flash, url_for, session
 from flask_ldap_login import LDAPLoginForm
 
 from .models import User
+
 
 blueprint = Blueprint('auth.ldap', __name__)
 

--- a/realms/modules/auth/local/__init__.py
+++ b/realms/modules/auth/local/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
 
-from ..models import Auth
+from realms.modules.auth.models import Auth
 
 Auth.register('local')

--- a/realms/modules/auth/local/__init__.py
+++ b/realms/modules/auth/local/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from ..models import Auth
 
 Auth.register('local')

--- a/realms/modules/auth/local/commands.py
+++ b/realms/modules/auth/local/commands.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import
+
 import click
-from realms.lib.util import random_string
-from realms.modules.auth.local.models import User
-from realms.lib.util import green, red, yellow
-from realms import cli_group
+
+from .models import User
+from ....lib.util import random_string
+from ....lib.util import green, red, yellow
+from .... import cli_group
 
 
 @cli_group(short_help="Auth Module")

--- a/realms/modules/auth/local/commands.py
+++ b/realms/modules/auth/local/commands.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 import click
 
+from realms import cli_group
+from realms.lib.util import random_string
+from realms.lib.util import green, red, yellow
 from .models import User
-from ....lib.util import random_string
-from ....lib.util import green, red, yellow
-from .... import cli_group
 
 
 @cli_group(short_help="Auth Module")

--- a/realms/modules/auth/local/forms.py
+++ b/realms/modules/auth/local/forms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from flask_wtf import Form
 from wtforms import StringField, PasswordField, validators
 

--- a/realms/modules/auth/local/hooks.py
+++ b/realms/modules/auth/local/hooks.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import
+
 from flask import current_app
 from flask_wtf import RecaptchaField
+
 from .forms import RegistrationForm
 
 

--- a/realms/modules/auth/local/models.py
+++ b/realms/modules/auth/local/models.py
@@ -1,11 +1,15 @@
+from __future__ import absolute_import
+
+from hashlib import sha256
+
 from flask import current_app, render_template
 from flask_login import logout_user, login_user
+from itsdangerous import URLSafeSerializer, BadSignature
+
 from realms import login_manager, db
 from realms.lib.model import Model
 from ..models import BaseUser
 from .forms import LoginForm
-from itsdangerous import URLSafeSerializer, BadSignature
-from hashlib import sha256
 
 
 @login_manager.token_loader

--- a/realms/modules/auth/local/models.py
+++ b/realms/modules/auth/local/models.py
@@ -8,7 +8,7 @@ from itsdangerous import URLSafeSerializer, BadSignature
 
 from realms import login_manager, db
 from realms.lib.model import Model
-from ..models import BaseUser
+from realms.modules.auth.models import BaseUser
 from .forms import LoginForm
 
 

--- a/realms/modules/auth/local/views.py
+++ b/realms/modules/auth/local/views.py
@@ -1,6 +1,10 @@
+from __future__ import absolute_import
+
 from flask import current_app, render_template, request, redirect, Blueprint, flash, url_for, session
-from realms.modules.auth.local.models import User
-from realms.modules.auth.local.forms import LoginForm, RegistrationForm
+
+from .models import User
+from .forms import LoginForm, RegistrationForm
+
 
 blueprint = Blueprint('auth.local', __name__)
 

--- a/realms/modules/auth/models.py
+++ b/realms/modules/auth/models.py
@@ -1,12 +1,16 @@
+from __future__ import absolute_import
+
+import importlib
+from hashlib import sha256
+
 from flask import current_app
 from flask_login import UserMixin, logout_user, AnonymousUserMixin
+from itsdangerous import URLSafeSerializer, BadSignature
+import bcrypt
+
 from realms import login_manager
 from realms.lib.util import gravatar_url
-from itsdangerous import URLSafeSerializer, BadSignature
-from hashlib import sha256
 from . import modules
-import bcrypt
-import importlib
 
 
 @login_manager.user_loader

--- a/realms/modules/auth/oauth/__init__.py
+++ b/realms/modules/auth/oauth/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
 
-from ..models import Auth
+from realms.modules.auth.models import Auth
 
 Auth.register('oauth')

--- a/realms/modules/auth/oauth/__init__.py
+++ b/realms/modules/auth/oauth/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from ..models import Auth
 
 Auth.register('oauth')

--- a/realms/modules/auth/oauth/models.py
+++ b/realms/modules/auth/oauth/models.py
@@ -4,8 +4,8 @@ from flask import session
 from flask_login import login_user
 from flask_oauthlib.client import OAuth
 
-from .... import config
-from ..models import BaseUser
+from realms import config
+from realms.modules.auth.models import BaseUser
 
 config = config.conf
 

--- a/realms/modules/auth/oauth/models.py
+++ b/realms/modules/auth/oauth/models.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+
 from flask import session
 from flask_login import login_user
 from flask_oauthlib.client import OAuth
 
-from realms import config
+from .... import config
 from ..models import BaseUser
 
 config = config.conf

--- a/realms/modules/auth/oauth/views.py
+++ b/realms/modules/auth/oauth/views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from flask import Blueprint, url_for, request, flash, redirect, session, current_app
 from .models import User
 

--- a/realms/modules/auth/tests.py
+++ b/realms/modules/auth/tests.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/realms/modules/auth/views.py
+++ b/realms/modules/auth/views.py
@@ -1,6 +1,10 @@
+from __future__ import absolute_import
+
 from flask import current_app, render_template, request, redirect, Blueprint, flash, url_for, session
 from flask_login import logout_user
+
 from realms.modules.auth.models import Auth
+
 
 blueprint = Blueprint('auth', __name__, template_folder='templates')
 

--- a/realms/modules/auth/views.py
+++ b/realms/modules/auth/views.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from flask import current_app, render_template, request, redirect, Blueprint, flash, url_for, session
 from flask_login import logout_user
 
-from realms.modules.auth.models import Auth
+from .models import Auth
 
 
 blueprint = Blueprint('auth', __name__, template_folder='templates')

--- a/realms/modules/search/__init__.py
+++ b/realms/modules/search/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/realms/modules/search/commands.py
+++ b/realms/modules/search/commands.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 import click
 from flask import current_app
 
-from ... import search, cli_group
-from ..wiki.models import Wiki
+from realms import search, cli_group
+from realms.modules.wiki.models import Wiki
 
 
 @cli_group(short_help="Search Module")

--- a/realms/modules/search/commands.py
+++ b/realms/modules/search/commands.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+
 import click
 from flask import current_app
-from realms import search, cli_group
-from realms.modules.wiki.models import Wiki
+
+from ... import search, cli_group
+from ..wiki.models import Wiki
 
 
 @cli_group(short_help="Search Module")

--- a/realms/modules/search/hooks.py
+++ b/realms/modules/search/hooks.py
@@ -1,5 +1,7 @@
-from realms.modules.wiki.models import WikiPage
-from realms import search
+from __future__ import absolute_import
+
+from ..wiki.models import WikiPage
+from ... import search
 
 
 @WikiPage.after('write')

--- a/realms/modules/search/hooks.py
+++ b/realms/modules/search/hooks.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-from ..wiki.models import WikiPage
-from ... import search
+from realms import search
+from realms.modules.wiki.models import WikiPage
 
 
 @WikiPage.after('write')

--- a/realms/modules/search/models.py
+++ b/realms/modules/search/models.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import
+
 import re
 import sys
 
 from flask import g, current_app
-from realms.lib.util import filename_to_cname
+
+from ...lib.util import filename_to_cname
 
 
 def simple(app):

--- a/realms/modules/search/models.py
+++ b/realms/modules/search/models.py
@@ -5,7 +5,7 @@ import sys
 
 from flask import g, current_app
 
-from ...lib.util import filename_to_cname
+from realms.lib.util import filename_to_cname
 
 
 def simple(app):

--- a/realms/modules/search/views.py
+++ b/realms/modules/search/views.py
@@ -1,6 +1,10 @@
+from __future__ import absolute_import
+
 from flask import render_template, request, Blueprint, current_app
 from flask_login import current_user
+
 from realms import search as search_engine
+
 
 blueprint = Blueprint('search', __name__, template_folder='templates')
 

--- a/realms/modules/wiki/__init__.py
+++ b/realms/modules/wiki/__init__.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
+
 import os
 import sys
-from realms.modules.wiki.models import Wiki
+
+from .models import Wiki
 
 
 def init(app):

--- a/realms/modules/wiki/assets.py
+++ b/realms/modules/wiki/assets.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ... import assets
+from realms import assets
 
 assets.register('editor.js',
                 'vendor/store-js/store.js',

--- a/realms/modules/wiki/assets.py
+++ b/realms/modules/wiki/assets.py
@@ -1,4 +1,6 @@
-from realms import assets
+from __future__ import absolute_import
+
+from ... import assets
 
 assets.register('editor.js',
                 'vendor/store-js/store.js',

--- a/realms/modules/wiki/hooks.py
+++ b/realms/modules/wiki/hooks.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import
+
 from flask import g, current_app
+
 from .models import Wiki
 
 

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -9,9 +9,9 @@ import yaml
 from dulwich.object_store import tree_lookup_path
 from dulwich.repo import Repo, NotGitRepository
 
-from ...lib.util import cname_to_filename, filename_to_cname
-from ... import cache
-from ...lib.hook import HookMixin
+from realms import cache
+from realms.lib.hook import HookMixin
+from realms.lib.util import cname_to_filename, filename_to_cname
 
 
 class PageNotFound(Exception):

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -1,13 +1,17 @@
+from __future__ import absolute_import
+
 import os
 import posixpath
 import re
+
 import ghdiff
 import yaml
 from dulwich.object_store import tree_lookup_path
 from dulwich.repo import Repo, NotGitRepository
-from realms.lib.util import cname_to_filename, filename_to_cname
-from realms import cache
-from realms.lib.hook import HookMixin
+
+from ...lib.util import cname_to_filename, filename_to_cname
+from ... import cache
+from ...lib.hook import HookMixin
 
 
 class PageNotFound(Exception):

--- a/realms/modules/wiki/tests.py
+++ b/realms/modules/wiki/tests.py
@@ -5,8 +5,8 @@ import json
 from nose.tools import *
 from flask import url_for
 
-from ...lib.util import cname_to_filename, filename_to_cname
-from ...lib.test import BaseTest
+from realms.lib.util import cname_to_filename, filename_to_cname
+from realms.lib.test import BaseTest
 
 
 class WikiBaseTest(BaseTest):

--- a/realms/modules/wiki/tests.py
+++ b/realms/modules/wiki/tests.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import
+
 import json
+
 from nose.tools import *
 from flask import url_for
-from realms.lib.util import cname_to_filename, filename_to_cname
-from realms.lib.test import BaseTest
+
+from ...lib.util import cname_to_filename, filename_to_cname
+from ...lib.test import BaseTest
 
 
 class WikiBaseTest(BaseTest):

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -1,10 +1,15 @@
+from __future__ import absolute_import
+
 import itertools
 import sys
 from datetime import datetime
+
 from flask import abort, g, render_template, request, redirect, Blueprint, flash, url_for, current_app
 from flask_login import login_required, current_user
+
 from realms.lib.util import to_canonical, remove_ext, gravatar_url
 from .models import PageNotFound
+
 
 blueprint = Blueprint('wiki', __name__, template_folder='templates',
                       static_folder='static', static_url_path='/static/wiki')

--- a/realms/version.py
+++ b/realms/version.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import
+
 __version__ = '0.8.1'

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(name='realms-wiki',
           'itsdangerous==0.24',
           'markdown2==2.3.1',
           'python-ldap==2.4.22',
-          'simplejson==3.6.3'
+          'simplejson==3.6.3',
+          'six=1.10.0'
       ],
       entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(name='realms-wiki',
           'markdown2==2.3.1',
           'python-ldap==2.4.22',
           'simplejson==3.6.3',
-          'six=1.10.0'
+          'six==1.10.0'
       ],
       entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from setuptools import setup, find_packages
 import os
+from setuptools import setup, find_packages
 
 if os.environ.get('USER', '') == 'vagrant':
     del os.link


### PR DESCRIPTION
It eliminates `import NAME` confusion with very common names (eg. `import ldap` is very ambiguous: can be a ldap module from realms-wiki, a ldap module from flask-ldap-login, or `python-ldap` module.

Also cleant up a bit the imports towards PEP8: builtin modules first, then 3rd party python packages, then local packages

thanks!
stephane
