### PR TITLE
add templates from modules to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,6 @@ recursive-include realms/static/css *
 recursive-include realms/static/js *
 recursive-include realms/static/vendor *
 recursive-include realms/templates *
+recursive-include realms/modules/auth/templates *
+recursive-include realms/modules/search/templates *
+recursive-include realms/modules/wiki/templates *


### PR DESCRIPTION
Hello,

install via pip seems broken.

```
virtualenv testrealms
source testrealms/bin/activate
pip install realms-wiki
realms-wiki dev
```

... gives in browser the exception: `TemplateNotFound: wiki/page.html"`

Looks like MANIFEST.in is missing paths to templates insides modules...
