### PR TITLE
Make sure module static files are included in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,5 @@
 include requirements.txt LICENSE README.md
-recursive-include realms/static/img *
-recursive-include realms/static/fonts *
-recursive-include realms/static/css *
-recursive-include realms/static/js *
-recursive-include realms/static/vendor *
-recursive-include realms/templates *
-recursive-include realms/modules/auth/templates *
-recursive-include realms/modules/search/templates *
-recursive-include realms/modules/wiki/templates *
+graft realms/static
+graft realms/templates
+graft realms/modules/**/static
+graft realms/modules/**/templates


### PR DESCRIPTION
Static files in modules were not being selected by MANIFEST.in, this fixes that. It also greatly simplifies the manifest file, and includes all modules static and template files without having to explicitly add new ones. One change is that it will now include all files in the static directory, instead of just the individual css, js, vendor subdirs. Is that an issue? I'm thinking nothing should be put in the static folder that isn't meant to be a part of the dist.