### PR TITLE
Support math typesetting by KaTeX

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "bootswatch-dist": "3.3.6-flatly",
     "bootbox": "4.4.0",
     "datatables": "1.10.11",
-    "datatables-plugins": "latest"
+    "datatables-plugins": "latest",
+    "katex": "latest"
   }
 }

--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -237,6 +237,8 @@ assets.register('main.js',
                 'vendor/parsleyjs/dist/parsley.js',
                 'vendor/datatables/media/js/jquery.dataTables.js',
                 'vendor/datatables-plugins/integration/bootstrap/3/dataTables.bootstrap.js',
+                'vendor/katex/dist/katex.min.js',
+                'vendor/katex/dist/contrib/auto-render.min.js',
                 'js/hbs-helpers.js',
                 'js/mdr.js',
                 'js/main.js')
@@ -246,6 +248,7 @@ assets.register('main.css',
                 'vendor/components-font-awesome/css/font-awesome.css',
                 'vendor/highlightjs/styles/github.css',
                 'vendor/datatables-plugins/integration/bootstrap/3/dataTables.bootstrap.css',
+                'vendor/katex/dist/katex.min.css',
                 'css/style.css')
 
 

--- a/realms/modules/wiki/templates/wiki/page.html
+++ b/realms/modules/wiki/templates/wiki/page.html
@@ -25,5 +25,7 @@
     $(function(){
       $("#page-content").html(MDR.convert({{ page.data|tojson|safe }}, {{ partials|d([])|tojson|safe }})).show();
     });
+    $(document).ready(function(){
+      renderMathInElement(document.body,{delimiters: [{left: "$$", right: "$$", display: true},{left: "$", right: "$", display: false}]})});
   </script>
 {% endblock %}


### PR DESCRIPTION
This pull request is a solution for #124.

I used [KaTeX](https://khan.github.io/KaTeX/) and [Auto-render extension](https://github.com/Khan/KaTeX/blob/master/contrib/auto-render/README.md) to display math formula.
Please check my [demo](http://wiki.kivantium.net/demo).

In this implimentation, expressions surrounded by `$` or `$$` is recognized as a math formula. Therefore it may cause unintended typesetting if there is `$` in existing documents.
 
There are some things to do
- [ ] support typesetting on the preview display in edit mode.
- [ ] users can choose typesetting enable or disable
- [ ] users can change deliminator by option

Thank you,
kivantium