### PR TITLE
Add cache timeout of 5s, now works with offline git commits

### DIFF
--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -220,7 +220,8 @@ def create_app(config=None):
 login_manager = LoginManager()
 
 db = SQLAlchemy()
-cache = Cache()
+# Add a 5 second timeout, to also work with offline git + text editor commits
+cache = Cache(config={'CACHE_DEFAULT_TIMEOUT': 5.0})
 assets = Assets()
 search = Search()
 ldap = MyLDAPLoginManager()


### PR DESCRIPTION
To me, the primary benefit of a git-and-file-based wiki is that one can also use plain git + text editor to maintain the wiki (in addition to using the beautiful browser interface).

Realms is currently incompatible with this type of usage, because it keeps its cached pages forever (unless the user makes a change using the Realms GUI). It will ignore a new git commit that was not made via the Realms GUI, because it finds its old cached HTML and thinks that old HTML is still valid.

This commit adds a 5 second cache timeout, thus causing offline git commits to show up no later than 5s later (when the Realms cache expires). The hard-coded magic number of 5s will limit the number of cache refreshes to 12 per second, which still provides good caching for busy servers, but now allows us SSH+vi users to easily create and maintain pages.
