### PR TITLE
Systemd docs

### DIFF
--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -220,7 +220,8 @@ def create_app(config=None):
 login_manager = LoginManager()
 
 db = SQLAlchemy()
-cache = Cache()
+# Add a 5 second timeout, to also work with offline git + text editor commits
+cache = Cache(config={'CACHE_DEFAULT_TIMEOUT': 5.0})
 assets = Assets()
 search = Search()
 ldap = MyLDAPLoginManager()


### PR DESCRIPTION
This updates the list of .deb packages so it works with Ubuntu 16.04.

It also gives an example systemd init script. (Ubuntu switched from Upstart to Systemd in release 15.04.)

(Please note, this does not constitute an endorsement of systemd.)