### PR TITLE
Fix relative paths on WSGI.

### DIFF
--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -35,7 +35,6 @@ try:
     running_on_wsgi = True
 except:
     running_on_wsgi = False
-    pass
 
 class Application(Flask):
 

--- a/realms/__init__.py
+++ b/realms/__init__.py
@@ -30,6 +30,12 @@ from realms.lib.util import to_canonical, remove_ext, mkdir_safe, gravatar_url, 
 from realms.lib.hook import HookModelMeta, HookMixin
 from realms.version import __version__
 
+try:
+    from mod_wsgi import version
+    running_on_wsgi = True
+except:
+    running_on_wsgi = False
+    pass
 
 class Application(Flask):
 
@@ -73,7 +79,11 @@ class Application(Flask):
 
             # Blueprint
             if hasattr(sources, 'views'):
-                self.register_blueprint(sources.views.blueprint, url_prefix=self.config['RELATIVE_PATH'])
+
+                if running_on_wsgi:
+                    self.register_blueprint(sources.views.blueprint, url_prefix='')
+                else:
+                    self.register_blueprint(sources.views.blueprint, url_prefix=self.config['RELATIVE_PATH'])
 
             # Click
             if hasattr(sources, 'commands'):
@@ -202,7 +212,7 @@ def create_app(config=None):
     def page_not_found(e):
         return render_template('errors/404.html'), 404
 
-    if app.config.get('RELATIVE_PATH'):
+    if not running_on_wsgi and app.config.get('RELATIVE_PATH'):
         @app.route("/")
         def root():
             return redirect(url_for(app.config.get('ROOT_ENDPOINT')))

--- a/realms/modules/wiki/static/js/editor.js
+++ b/realms/modules/wiki/static/js/editor.js
@@ -76,7 +76,7 @@ var deletePage = function() {
   }).done(function(data) {
     var msg = 'Deleted page: ' + pageName;
     bootbox.alert(msg, function() {
-      location.href = '/';
+      location.href = Config['RELATIVE_PATH'] + '/';
     });
   }).fail(function(data, status, error) {
     bootbox.alert('Error deleting page!');


### PR DESCRIPTION
This is a thorny issue and I do not fully understand how this is supposed to work on the wsgi/flask level.

What I do know is this: on WSGI, we need to know our `RELATIVE_PATH` for edit/delete (which are form submissions), but our blueprints need to be relative to /, because WSGI does the translation for us.

This patch should at least have minimal impact.