### PR TITLE
Added ability to serve static Files from Git repository (such as images)

### DIFF
--- a/realms/lib/util.py
+++ b/realms/lib/util.py
@@ -71,8 +71,29 @@ def extract_name(file_path):
     return os.path.basename(file_path)
 
 
+def get_ext(path):
+    match = re.match(r"^[^.]+\.([^.]+)$", path)
+    if match:
+        return match.group(1)
+    else:
+        return ''
+
+
 def remove_ext(path):
     return re.sub(r"\..*$", "", path)
+
+
+def is_markdown(path):
+    ext = get_ext(path)
+    print "Test: " + ext
+    if ext == '':
+        return True
+    elif ext == 'md':
+        return True
+    elif ext == 'mdwn':
+        return True
+    else:
+        return False
 
 
 def clean_url(url):
@@ -127,7 +148,10 @@ def cname_to_filename(cname):
     :return: str -- Filename
 
     """
-    return sanitize(cname) + ".md"
+    if remove_ext(cname) != cname:
+        return cname
+    else:
+        return sanitize(cname) + ".md"
 
 
 def filename_to_cname(filename):

--- a/realms/lib/util.py
+++ b/realms/lib/util.py
@@ -72,11 +72,8 @@ def extract_name(file_path):
 
 
 def get_ext(path):
-    match = re.match(r"^[^.]+\.([^.]+)$", path)
-    if match:
-        return match.group(1)
-    else:
-        return ''
+    (file, ext) = os.path.splitext(path)
+    return ext
 
 
 def remove_ext(path):

--- a/realms/modules/wiki/models.py
+++ b/realms/modules/wiki/models.py
@@ -98,16 +98,21 @@ class WikiPage(HookMixin):
         self.wiki = wiki
 
     @property
-    def data(self):
+    def file(self):
         cache_key = self._cache_key('data')
         cached = cache.get(cache_key)
         if cached:
             return cached
 
         mode, sha = tree_lookup_path(self.wiki.repo.get_object, self.wiki.repo[self.sha].tree, self.filename.encode())
-        data = self.wiki.repo[sha].data
-        cache.set(cache_key, data)
-        return data
+        file = self.wiki.repo[sha]
+        cache.set(cache_key, file)
+        return file
+
+
+    @property
+    def data(self):
+        return self.file.data
 
     @property
     def history(self):

--- a/realms/modules/wiki/templates/wiki/edit.html
+++ b/realms/modules/wiki/templates/wiki/edit.html
@@ -26,7 +26,6 @@
     <script src="{{ url_for('wiki.static', filename='js/collaboration/togetherjs.js') }}"></script>
     <script src="https://togetherjs.com/togetherjs-min.js"></script>
   {% endif %}
-
 {% endblock %}
 
 {% block body %}

--- a/realms/modules/wiki/views.py
+++ b/realms/modules/wiki/views.py
@@ -10,7 +10,7 @@ from werkzeug.contrib.atom import AtomFeed
 from flask_login import login_required, current_user
 
 from realms.version import __version__
-from realms.lib.util import to_canonical, remove_ext, gravatar_url
+from realms.lib.util import to_canonical, remove_ext, gravatar_url, is_markdown
 from .models import PageNotFound
 
 blueprint = Blueprint('wiki', __name__, template_folder='templates',
@@ -308,6 +308,12 @@ def page(name):
     data = g.current_wiki.get_page(cname)
 
     if data:
-        return render_template('wiki/page.html', name=cname, page=data, partials=_partials(data.imports))
+        if is_markdown(cname):
+            return render_template('wiki/page.html', name=cname, page=data, partials=_partials(data.imports))
+        else:
+            response = make_response(data.data)
+            response.headers['Content-Type'] = 'image/png'
+            response.headers['Content-Disposition'] = 'attachment; filename=img.png'
+            return response
     else:
         return redirect(url_for('wiki.create', name=cname))


### PR DESCRIPTION
To make a wiki really effective you need the ability to upload and serve Files stored together with the text content. This is a first approach to recognizing which files might be markdown and rendering only those, serving all other files as raw data.

I'll later submit a pull request which will include file upload support but I want to discuss the way in which it would do that before implementing that. I'll bring up a discussion about that on the relevant issue.
