### PR TITLE
Ldap login description

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,18 @@ It is similar to LDAP/TLS. Just add a START_TLS option:
 
 The VALIDATE option can be used here too.
 
+#### LDAP Login custom header
+
+The default LDAP login header is **LDAP Login**, but **LDAP** alone is a bit vague sometimes.
+
+You can set a custom LDAP Login header like so:
+
+    "LDAP": {
+        "LOGIN_DESCRIPTION": "ACME LDAP Login <i>(yor email account)</i>",
+        ...
+    }
+
+
 #### Configuration change for TLS
 
 Please note that the TLS/START_TLS configuration changed from previous versions of Realms. The old way that was from

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ The default LDAP login header is **LDAP Login**, but **LDAP** alone is a bit vag
 You can set a custom LDAP Login header like so:
 
     "LDAP": {
-        "LOGIN_DESCRIPTION": "ACME LDAP Login <i>(yor email account)</i>",
+        "LOGIN_DESCRIPTION": "ACME LDAP Login <i>(your email account)</i>",
         ...
     }
 

--- a/realms/modules/auth/templates/auth/ldap/login.html
+++ b/realms/modules/auth/templates/auth/ldap/login.html
@@ -1,5 +1,5 @@
 {% from 'macros.html' import render_form, render_field %}
-{% if config.get('AUTH_LOCAL_ENABLE') %}
+{% if config.AUTH_LOCAL_ENABLE %}
     <button type="button" class="btn btn-info" data-toggle="modal" data-target="#ldap-modal">
       <i class="fa fa-folder-open-o"></i>&nbsp; Login with LDAP
     </button>
@@ -21,7 +21,13 @@
       </div>
     </div>
 {% else %}
-    <h3><i class="fa fa-folder-open-o"></i>&nbsp;LDAP Login</h3>
+    <h3><i class="fa fa-folder-open-o"></i>&nbsp;
+{% if config.LDAP.LOGIN_DESCRIPTION %}
+      {{ config.LDAP.LOGIN_DESCRIPTION|safe }}
+{% else %}
+      LDAP Login
+{% endif %}
+    </h3>
     {% call render_form(form, action_url=url_for('auth.ldap.login'), action_text='Login', btn_class='btn btn-primary') %}
     {{ render_field(form.username, placeholder='Username', type='text', required=1) }}
     {{ render_field(form.password, placeholder='Password', type='password', required=1) }}


### PR DESCRIPTION
This makes the LDAP Login header text configurable.

I wanted this because I often appreciate a small hint which of my too-many accounts I am supposed to use.

README is updated.

This is how it might look like:

![screen shot 2017-11-30 at 00 32 40](https://user-images.githubusercontent.com/152872/33404915-57eee45a-d566-11e7-8f93-2f177ff7cba2.png)
